### PR TITLE
Fix nft.queryOwner can not fetch owner's all tokens 

### DIFF
--- a/modules/nft/nft.go
+++ b/modules/nft/nft.go
@@ -154,10 +154,6 @@ func (nc nftClient) QuerySupply(denom, creator string) (uint64, sdk.Error) {
 }
 
 func (nc nftClient) QueryOwner(creator, denom string, pageReq *query.PageRequest) (QueryOwnerResp, sdk.Error) {
-	if len(denom) == 0 {
-		return QueryOwnerResp{}, sdk.Wrapf("denom is required")
-	}
-
 	if err := sdk.ValidateAccAddress(creator); err != nil {
 		return QueryOwnerResp{}, sdk.Wrap(err)
 	}


### PR DESCRIPTION
The denomID parameter is allowed to be empty.